### PR TITLE
Update installation-cli.md broken link

### DIFF
--- a/guide/3.0/installation-cli.md
+++ b/guide/3.0/installation-cli.md
@@ -10,6 +10,7 @@ windows_link: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.0
 linux32_link: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.0.0/nightly_6/cloudify-cli_3.0.0-ga-b6_i386.deb
 linux64_link: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.0.0/nightly_6/cloudify-cli_3.0.0-ga-b6_amd64.deb
 venv_link: http://virtualenv.readthedocs.org/en/latest/
+simple_install_link: installation-openstack-provider.html
 ---
 {%summary%}{{page.abstract}}{%endsummary%}
 


### PR DESCRIPTION
page link at the bottom of the file was not defined leading to a link back to the page itself.  Added link definition to existing VM installation page.
