### PR TITLE
fix(linkchecker): tell linkchecker not to verify links with guide/[a-z] ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ cache: bundler
 before_install: pip install --user LinkChecker
 script:
   - bundle exec jekyll serve --detach
-  - /home/travis/.local/bin/linkchecker http://127.0.0.1:4000/ --anchors --no-status --ignore-url=guide/2.7 --ignore-url=guide/2.6 --ignore-url=blog/ --ignore-url=^mailto --ignore-url=bower_components --ignore-url=/downloads/get_cloudify_2x.html
+  - /home/travis/.local/bin/linkchecker http://127.0.0.1:4000/ --anchors --no-status --ignore-url=guide/2.7 --ignore-url=guide/2.6 --ignore-url=blog/ --ignore-url=^mailto --ignore-url=bower_components --ignore-url=/downloads/get_cloudify_2x.html --ignore-url=guide/[a-z]
 after_success:
   - if [ $TRAVIS_BRANCH == "master" ]; then bundle exec s3_website push; fi


### PR DESCRIPTION
...pattern

our mechanism for version-less links to the guide is incorrect. currently it returns 404 and in javascript redirects the page. in order to make this process work with linkchecker we need to come up with a different approach.