### PR TITLE
winrm configuration syntax fix.

### DIFF
--- a/source/guide/3.0/plugin-windows-agent-installer.md
+++ b/source/guide/3.0/plugin-windows-agent-installer.md
@@ -30,7 +30,7 @@ winrm s winrm/config/service @{AllowUnencrypted="true";MaxConcurrentOperationsPe
 winrm s winrm/config/service/auth @{Basic="true"}
 winrm s winrm/config/winrs @{MaxShellsPerUser="2147483647"}
 {%endhighlight%}
-the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes like winrm set winrm/config/service/auth '@{Basic="true"}'
+the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes. (e.g. winrm set winrm/config/service/auth '@{Basic="true"}')
 
 {%note title=Note%}
 These settings provide unencrypted WinRM access to the machine. We're working on adding Kerberos support.

--- a/source/guide/3.0/plugin-windows-agent-installer.md
+++ b/source/guide/3.0/plugin-windows-agent-installer.md
@@ -26,9 +26,9 @@ This plugin can only install agents on an image that meets the following set of 
 To enable WinRM on the machine execute these commands:
 {% highlight bash %}
 winrm quickconfig
-winrm s winrm/config/service @{AllowUnencrypted="true";MaxConcurrentOperationsPerUser="4294967295"}
-winrm s winrm/config/service/auth @{Basic="true"}
-winrm s winrm/config/winrs @{MaxShellsPerUser="2147483647"}
+winrm s winrm/config/service '@{AllowUnencrypted="true";MaxConcurrentOperationsPerUser="4294967295"}'
+winrm s winrm/config/service/auth '@{Basic="true"}'
+winrm s winrm/config/winrs '@{MaxShellsPerUser="2147483647"}'
 {%endhighlight%}
 
 {%note title=Note%}

--- a/source/guide/3.0/plugin-windows-agent-installer.md
+++ b/source/guide/3.0/plugin-windows-agent-installer.md
@@ -26,10 +26,11 @@ This plugin can only install agents on an image that meets the following set of 
 To enable WinRM on the machine execute these commands:
 {% highlight bash %}
 winrm quickconfig
-winrm s winrm/config/service '@{AllowUnencrypted="true";MaxConcurrentOperationsPerUser="4294967295"}'
-winrm s winrm/config/service/auth '@{Basic="true"}'
-winrm s winrm/config/winrs '@{MaxShellsPerUser="2147483647"}'
+winrm s winrm/config/service @{AllowUnencrypted="true";MaxConcurrentOperationsPerUser="4294967295"}
+winrm s winrm/config/service/auth @{Basic="true"}
+winrm s winrm/config/winrs @{MaxShellsPerUser="2147483647"}
 {%endhighlight%}
+the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes like winrm set winrm/config/service/auth '@{Basic="true"}'
 
 {%note title=Note%}
 These settings provide unencrypted WinRM access to the machine. We're working on adding Kerberos support.

--- a/source/guide/3.1/plugin-windows-agent-installer.md
+++ b/source/guide/3.1/plugin-windows-agent-installer.md
@@ -41,6 +41,7 @@ winrm s winrm/config/service @{AllowUnencrypted="true";MaxConcurrentOperationsPe
 winrm s winrm/config/service/auth @{Basic="true"}
 winrm s winrm/config/winrs @{MaxShellsPerUser="2147483647"}
 {%endhighlight%}
+the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes like winrm set winrm/config/service/auth '@{Basic="true"}'
 
 {%note title=Note%}
 These settings provide unencrypted WinRM access to the machine. We're working on adding Kerberos support.

--- a/source/guide/3.1/plugin-windows-agent-installer.md
+++ b/source/guide/3.1/plugin-windows-agent-installer.md
@@ -41,7 +41,7 @@ winrm s winrm/config/service @{AllowUnencrypted="true";MaxConcurrentOperationsPe
 winrm s winrm/config/service/auth @{Basic="true"}
 winrm s winrm/config/winrs @{MaxShellsPerUser="2147483647"}
 {%endhighlight%}
-the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes like winrm set winrm/config/service/auth '@{Basic="true"}'
+the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes. (e.g. winrm set winrm/config/service/auth '@{Basic="true"}')
 
 {%note title=Note%}
 These settings provide unencrypted WinRM access to the machine. We're working on adding Kerberos support.

--- a/source/guide/3.2/plugin-windows-agent-installer.md
+++ b/source/guide/3.2/plugin-windows-agent-installer.md
@@ -41,6 +41,7 @@ winrm s winrm/config/service @{AllowUnencrypted="true";MaxConcurrentOperationsPe
 winrm s winrm/config/service/auth @{Basic="true"}
 winrm s winrm/config/winrs @{MaxShellsPerUser="2147483647"}
 {%endhighlight%}
+the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes like winrm set winrm/config/service/auth '@{Basic="true"}'
 
 {%note title=Note%}
 These settings provide unencrypted WinRM access to the machine. We're working on adding Kerberos support.

--- a/source/guide/3.2/plugin-windows-agent-installer.md
+++ b/source/guide/3.2/plugin-windows-agent-installer.md
@@ -41,7 +41,7 @@ winrm s winrm/config/service @{AllowUnencrypted="true";MaxConcurrentOperationsPe
 winrm s winrm/config/service/auth @{Basic="true"}
 winrm s winrm/config/winrs @{MaxShellsPerUser="2147483647"}
 {%endhighlight%}
-the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes like winrm set winrm/config/service/auth '@{Basic="true"}'
+the above winrm commands will fail in Windows Server 2012 (with PowerShell2), you need to put the @{...} in single quotes. (e.g. winrm set winrm/config/service/auth '@{Basic="true"}')
 
 {%note title=Note%}
 These settings provide unencrypted WinRM access to the machine. We're working on adding Kerberos support.


### PR DESCRIPTION
Some arguments should be surrounded with " ' "