### PR TITLE
No http:// in CloudifyClient() host spec

### DIFF
--- a/source/guide/3.2/apis-rest-client-python.md
+++ b/source/guide/3.2/apis-rest-client-python.md
@@ -23,7 +23,7 @@ Here is an example of how to get blueprints
 
 from cloudify_rest_client import CloudifyClient
 
-client = CloudifyClient('http://MANAGER_HOST')
+client = CloudifyClient('MANAGER_HOST')
 blueprints = client.blueprints.list()
 
 for blueprint in blueprints:


### PR DESCRIPTION
As of 3.2.1, it gives a name resolution failure. Works fine without the http://.